### PR TITLE
Update HitMarker to 2.2.0

### DIFF
--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -157,10 +157,8 @@ public void OnPluginStart()
 	AutoExecConfig(true, "Hitmarkers");
 
 	// Plugin commands
-	RegConsoleCmd("sm_hm", Command_Hitmarkers, "Open hitmarkers settings");
 	RegConsoleCmd("sm_hitmarker", Command_Hitmarkers, "Open hitmarker settings");
 	RegConsoleCmd("sm_hitmarkers", Command_Hitmarkers, "Open hitmarker settings");
-	RegConsoleCmd("sm_sd", Command_Hitmarkers, "Open hitmarkers settings");
 	RegConsoleCmd("sm_showdamage", Command_Hitmarkers, "Open hitmarkers settings");
 
 	RegConsoleCmd("sm_headhitcolor", Command_HeadColor, "Change your zombie hitmarker color.");
@@ -169,7 +167,6 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_bodyhitcolor", Command_BodyColor, "Change your zombie hitmarker color.");
 	RegConsoleCmd("sm_bodyhitcolour", Command_BodyColor, "Change your zombie hitmarker color.");
 
-	RegConsoleCmd("sm_hits", Command_Hitsound, "Bring up hitsounds settings menu");
 	RegConsoleCmd("sm_hitsound", Command_Hitsound, "Bring up hitsounds settings menu");
 	RegConsoleCmd("sm_hitsounds", Command_Hitsound, "Bring up hitsounds settings menu");
 

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -287,17 +287,17 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 	// Get client settings native
 	CreateNative("GetHitmarkerStatus", Native_GetHitmarkerStatus);
-	CreateNative("GetHitsoundStatus", Native_GetHitsoundStatus);
-	CreateNative("GetHitsoundVolume", Native_GetHitsoundVolume);
+	CreateNative("GetHitsoundStatus",  Native_GetHitsoundStatus);
+	CreateNative("GetHitsoundVolume",  Native_GetHitsoundVolume);
 
 	// Change client settings native
-	CreateNative("ToggleHitmarker", Native_ToggleHitmarker);
-	CreateNative("ToggleHitsound", Native_ToggleHitsound);
+	CreateNative("ToggleHitmarker",   Native_ToggleHitmarker);
+	CreateNative("ToggleHitsound",    Native_ToggleHitsound);
 	CreateNative("SetHitsoundVolume", Native_SetHitsoundVolume);
 
 	// Menu native
 	CreateNative("OpenHitmarkerMenu", Native_OpenHitmarkerMenu);
-	CreateNative("OpenHitsoundMenu", Native_OpenHitsoundMenu);
+	CreateNative("OpenHitsoundMenu",  Native_OpenHitsoundMenu);
 
 	return APLRes_Success;
 }
@@ -308,18 +308,9 @@ public int Native_GetHitmarkerStatus(Handle plugin, int numParams)
 	HitmarkerType type = view_as<HitmarkerType>(GetNativeCell(2));
 	switch (type)
 	{
-		case Hitmarker_Damage:
-		{
-			return g_HM_pData[client].damage;
-		}
-		case Hitmarker_Enable:
-		{
-			return g_HM_pData[client].enable;
-		}
-		case Hitmarker_Rank:
-		{
-			return g_HM_pData[client].health;
-		}
+		case Hitmarker_Damage: return g_HM_pData[client].damage;
+		case Hitmarker_Enable: return g_HM_pData[client].enable;
+		case Hitmarker_Rank:   return g_HM_pData[client].health;
 	}
 	return 1;
 }
@@ -330,18 +321,9 @@ public int Native_ToggleHitmarker(Handle plugin, int numParams)
 	HitmarkerType type = view_as<HitmarkerType>(GetNativeCell(2));
 	switch (type)
 	{
-		case Hitmarker_Damage:
-		{
-			InternalToggleDamage(client);
-		}
-		case Hitmarker_Enable:
-		{
-			InternalToggleHitmarker(client);
-		}
-		case Hitmarker_Rank:
-		{
-			InternalToggleShowHealth(client);
-		}
+		case Hitmarker_Damage: InternalToggleDamage(client);
+		case Hitmarker_Enable: InternalToggleHitmarker(client);
+		case Hitmarker_Rank:   InternalToggleShowHealth(client);
 	}
 	return 1;
 }
@@ -352,18 +334,9 @@ public int Native_OpenHitmarkerMenu(Handle plugin, int numParams)
 	MenuType type = view_as<MenuType>(GetNativeCell(2));
 	switch (type)
 	{
-		case Menu_Hitmarker:
-		{
-			HitmarkerMenu(client);
-		}
-		case Menu_HeadColor:
-		{
-			HeadColor(client);
-		}
-		case Menu_BodyColor:
-		{
-			BodyColor(client);
-		}
+		case Menu_Hitmarker: HitmarkerMenu(client);
+		case Menu_HeadColor: HeadColor(client);
+		case Menu_BodyColor: BodyColor(client);
 	}
 	return 1;
 }
@@ -374,12 +347,9 @@ public int Native_GetHitsoundStatus(Handle plugin, int numParams)
 	SoundType type = view_as<SoundType>(GetNativeCell(2));
 	switch (type)
 	{
-		case Sound_Zombie:
-			return g_HS_pData[client].enable;
-		case Sound_Boss:
-			return g_HS_pData[client].boss;
-		case Sound_Detailed:
-			return g_HS_pData[client].detailed;
+		case Sound_Zombie:   return g_HS_pData[client].enable;
+		case Sound_Boss:     return g_HS_pData[client].boss;
+		case Sound_Detailed: return g_HS_pData[client].detailed;
 	}
 	return 1;
 }
@@ -391,15 +361,13 @@ public any Native_GetHitsoundVolume(Handle plugin, int numParams)
 
 public int Native_ToggleHitsound(Handle plugin, int numParams)
 {
+	int client = GetNativeCell(1);
 	SoundType type = view_as<SoundType>(GetNativeCell(2));
 	switch (type)
 	{
-		case Sound_Zombie:
-			ToggleZombieHitsound(GetNativeCell(1));
-		case Sound_Boss:
-			ToggleBossHitsound(GetNativeCell(1));
-		case Sound_Detailed:
-			ToggleDetailedHitsound(GetNativeCell(1));
+		case Sound_Zombie:   ToggleZombieHitsound(client);
+		case Sound_Boss:     ToggleBossHitsound(client);
+		case Sound_Detailed: ToggleDetailedHitsound(client);
 	}
 	return 1;
 }
@@ -564,10 +532,10 @@ void LoadHitsoundSettings(int client)
 	char buffer[64];
 	g_cHitsoundSettings.Get(client, buffer, sizeof(buffer));
 
-	bool defaultEnable = true;
-	bool defaultBoss = true;
+	bool defaultEnable   = true;
+	bool defaultBoss     = true;
 	bool defaultDetailed = false;
-	int defaultVolume = DEFAULT_VOLUME_INT; // 0..100
+	int defaultVolume    = DEFAULT_VOLUME_INT; // 0..100
 
 	if (buffer[0] == '\0')
 	{
@@ -583,23 +551,23 @@ void LoadHitsoundSettings(int client)
 	char parts[4][8];
 	int numParts = ExplodeString(buffer, "|", parts, sizeof(parts), sizeof(parts[]));
 
-	bool enable = defaultEnable;
-	bool boss = defaultBoss;
+	bool enable   = defaultEnable;
+	bool boss     = defaultBoss;
 	bool detailed = defaultDetailed;
-	int volume = defaultVolume;
+	int volume    = defaultVolume;
 
-	if (numParts >= 1) enable = StringToInt(parts[0]) == 1;
-	if (numParts >= 2) boss = StringToInt(parts[1]) == 1;
+	if (numParts >= 1) enable   = StringToInt(parts[0]) == 1;
+	if (numParts >= 2) boss     = StringToInt(parts[1]) == 1;
 	if (numParts >= 3) detailed = StringToInt(parts[2]) == 1;
-	if (numParts >= 4) volume = StringToInt(parts[3]);
+	if (numParts >= 4) volume   = StringToInt(parts[3]);
 
 	if (volume < 0) volume = 0; if (volume > 100) volume = 100;
 
-	g_HS_pData[client].enable = enable;
-	g_HS_pData[client].boss = boss;
+	g_HS_pData[client].enable   = enable;
+	g_HS_pData[client].boss     = boss;
 	g_HS_pData[client].detailed = detailed;
-	g_HS_pData[client].volume = volume;
-	g_HS_pData[client].fVolume = volume / 100.0;
+	g_HS_pData[client].volume   = volume;
+	g_HS_pData[client].fVolume  = volume / 100.0;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -649,14 +617,9 @@ public Action Command_HeadColor(int client, int args)
 	GetCmdArg(3, buffer, sizeof(buffer));
 	b = StringToInt(buffer);
 
-	if (r > 255) r = 255;
-	else if (r < 0) r = 0;
-
-	if (g > 255) g = 255;
-	else if (g < 0) g = 0;
-
-	if (b > 255) b = 255;
-	else if (b < 0) b = 0;
+	if (r > 255) r = 255; if (r < 0) r = 0;
+	if (g > 255) g = 255; if (g < 0) g = 0;
+	if (b > 255) b = 255; if (b < 0) b = 0;
 
 	g_HM_pData[client].headColor[0] = r;
 	g_HM_pData[client].headColor[1] = g;
@@ -686,14 +649,9 @@ public Action Command_BodyColor(int client, int args)
 	GetCmdArg(3, buffer, sizeof(buffer));
 	b = StringToInt(buffer);
 
-	if (r > 255) r = 255;
-	else if (r < 0) r = 0;
-
-	if (g > 255) g = 255;
-	else if (g < 0) g = 0;
-
-	if (b > 255) b = 255;
-	else if (b < 0) b = 0;
+	if (r > 255) r = 255; if (r < 0) r = 0;
+	if (g > 255) g = 255; if (g < 0) g = 0;
+	if (b > 255) b = 255; if (b < 0) b = 0;
 
 	g_HM_pData[client].bodyColor[0] = r;
 	g_HM_pData[client].bodyColor[1] = g;
@@ -738,7 +696,6 @@ public Action Command_Hitsound(int client, int args)
 		if (len != 0 && StringToIntEx(buffer, input) == len)
 		{
 			float fVolume = input / 100.0;
-
 			g_HS_pData[client].volume = input;
 			g_HS_pData[client].fVolume = fVolume;
 			SaveHitsoundSettings(client);
@@ -762,12 +719,9 @@ void InternalToggleHitmarker(int client)
 	SaveHitmarkerSettings(client);
 	switch (g_HM_pData[client].enable)
 	{
-		case 0:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Disabled");
-		case 1:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Enabled");
-		case 2:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker All");
+		case 0: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Disabled");
+		case 1: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Enabled");
+		case 2: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker All");
 	}
 }
 
@@ -780,12 +734,9 @@ void InternalToggleDamage(int client)
 	SaveHitmarkerSettings(client);
 	switch (g_HM_pData[client].damage)
 	{
-		case 0:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Disabled");
-		case 1:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Enabled");
-		case 2:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Rank");
+		case 0: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Disabled");
+		case 1: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Enabled");
+		case 2: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Rank");
 	}
 }
 
@@ -798,12 +749,9 @@ void InternalToggleDisplayType(int client)
 	SaveHitmarkerSettings(client);
 	switch (g_HM_pData[client].type)
 	{
-		case 0:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Center");
-		case 1:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Game Text");
-		case 2:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Hint Text");
+		case 0: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Center");
+		case 1: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Game Text");
+		case 2: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Hint Text");
 	}
 }
 
@@ -816,12 +764,9 @@ void InternalToggleShowHealth(int client)
 	SaveHitmarkerSettings(client);
 	switch (g_HM_pData[client].health)
 	{
-		case 0:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Disabled");
-		case 1:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Enabled");
-		case 2:
-			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Name");
+		case 0: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Disabled");
+		case 1: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Enabled");
+		case 2: CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Name");
 	}
 }
 
@@ -1077,10 +1022,7 @@ public void SettingsMenuHandler(int client, CookieMenuAction action, any info, c
 {
 	switch (action)
 	{
-		case CookieMenuAction_SelectOption:
-		{
-			HitmarkerMenu(client);
-		}
+		case CookieMenuAction_SelectOption: HitmarkerMenu(client);
 	}
 }
 
@@ -1101,12 +1043,9 @@ public void HitmarkerMenu(int client)
 
 		switch (g_HM_pData[client].enable)
 		{
-			case 0:
-				Format(buffer, sizeof(buffer), "Disabled");
-			case 1:
-				Format(buffer, sizeof(buffer), "Enabled");
-			case 2:
-				Format(buffer, sizeof(buffer), "Enabled (Players + Bosses)");
+			case 0: Format(buffer, sizeof(buffer), "Disabled");
+			case 1: Format(buffer, sizeof(buffer), "Enabled");
+			case 2: Format(buffer, sizeof(buffer), "Enabled (Players + Bosses)");
 		}
 		Format(buffer, sizeof(buffer), "Hitmarkers: %s", buffer);
 		menu.AddItem("toggle", buffer);
@@ -1116,12 +1055,9 @@ public void HitmarkerMenu(int client)
 		menu.SetTitle("Hitmarkers\n \nCurrent Style (%d/%d):\n%s", g_HM_pData[client].style + 1, sizeof(g_sHitStyles), g_sHitStyles[g_HM_pData[client].style]);
 		switch (g_HM_pData[client].enable)
 		{
-			case 0:
-				Format(buffer, sizeof(buffer), "Disabled");
-			case 1:
-				Format(buffer, sizeof(buffer), "Enabled");
-			case 2:
-				Format(buffer, sizeof(buffer), "Enabled (Players + Bosses)");
+			case 0: Format(buffer, sizeof(buffer), "Disabled");
+			case 1: Format(buffer, sizeof(buffer), "Enabled");
+			case 2: Format(buffer, sizeof(buffer), "Enabled (Players + Bosses)");
 		}
 		Format(buffer, sizeof(buffer), "Hitmarkers: %s\n \nCustomize Hitmarker:", buffer);
 		menu.AddItem("toggle", buffer);
@@ -1149,24 +1085,18 @@ public void HitmarkerMenu(int client)
 
 	switch (g_HM_pData[client].damage)
 	{
-		case 0:
-			Format(buffer, sizeof(buffer), "Off");
-		case 1:
-			Format(buffer, sizeof(buffer), "On");
-		case 2:
-			Format(buffer, sizeof(buffer), "On (+Rank)");
+		case 0: Format(buffer, sizeof(buffer), "Off");
+		case 1: Format(buffer, sizeof(buffer), "On");
+		case 2: Format(buffer, sizeof(buffer), "On (+Rank)");
 	}
 	Format(buffer, sizeof(buffer), "Show Damage: %s", buffer);
 	menu.AddItem("showdamage", buffer);
 
 	switch (g_HM_pData[client].health)
 	{
-		case 0:
-			Format(buffer, sizeof(buffer), "Off");
-		case 1:
-			Format(buffer, sizeof(buffer), "On");
-		case 2:
-			Format(buffer, sizeof(buffer), "On (+Victim name)");
+		case 0: Format(buffer, sizeof(buffer), "Off");
+		case 1: Format(buffer, sizeof(buffer), "On");
+		case 2: Format(buffer, sizeof(buffer), "On (+Victim name)");
 	}
 	Format(buffer, sizeof(buffer), "Show Health: %s", buffer);
 	menu.AddItem("showhealth", buffer);
@@ -1196,17 +1126,12 @@ public int HitmarkerMenuHandler(Handle menu, MenuAction action, int client, int 
 					g_HM_pData[client].style = 0;
 
 				SaveHitmarkerSettings(client);
-
 				HitmarkerMenu(client);
 			}
 			else if (strcmp(info, "headcolor", false) == 0)
-			{
 				HeadColor(client);
-			}
 			else if (strcmp(info, "bodycolor", false) == 0)
-			{
 				BodyColor(client);
-			}
 			else if (strcmp(info, "showdamage", false) == 0)
 			{
 				InternalToggleDamage(client);
@@ -1223,9 +1148,7 @@ public int HitmarkerMenuHandler(Handle menu, MenuAction action, int client, int 
 				HitmarkerMenu(client);
 			}
 			else if (strcmp(info, "hitsounds", false) == 0)
-			{
 				OpenHitsoundMenu(client);
-			}
 		}
 		case MenuAction_Cancel:
 		{
@@ -1307,7 +1230,6 @@ public int HeadColorHandler(Handle menu, MenuAction action, int client, int sele
 			}
 
 			SaveHitmarkerColors(client);
-
 			HeadColor(client);
 		}
 		case MenuAction_Cancel:
@@ -1390,7 +1312,6 @@ public int BodyColorHandler(Handle menu, MenuAction action, int client, int sele
 			}
 
 			SaveHitmarkerColors(client);
-
 			BodyColor(client);
 		}
 		case MenuAction_Cancel:
@@ -1455,22 +1376,20 @@ public int MenuHandler_HitMarker(Menu menu, MenuAction action, int client, int s
 		{
 			switch (selection)
 			{
-				case 0:
-					ToggleZombieHitsound(client);
-				case 1:
-					ToggleBossHitsound(client);
-				case 2:
-					ToggleDetailedHitsound(client);
+				case 0: ToggleZombieHitsound(client);
+				case 1: ToggleBossHitsound(client);
+				case 2: ToggleDetailedHitsound(client);
 				case 3:
 				{
 					g_HS_pData[client].fVolume = g_HS_pData[client].fVolume - 0.1;
-					if (g_HS_pData[client].fVolume <= 0.0) g_HS_pData[client].fVolume = 1.0;
+					if (g_HS_pData[client].fVolume <= 0.0)
+						g_HS_pData[client].fVolume = 1.0;
 
 					g_HS_pData[client].volume = g_HS_pData[client].volume - 10;
-					if (g_HS_pData[client].volume <= 0) g_HS_pData[client].volume = 100;
+					if (g_HS_pData[client].volume <= 0)
+						g_HS_pData[client].volume = 100;
 
 					SaveHitsoundSettings(client);
-
 					CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Volume", g_HS_pData[client].volume);
 				}
 			}

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -255,10 +255,10 @@ public void OnConVarChange(ConVar convar, char[] oldValue, char[] newValue)
 public void OnConfigsExecuted()
 {
 	PrecacheSounds();
-	GetConVarString(g_cvHitsound, g_sHitsoundPath, sizeof(g_sHitsoundPath));
-	GetConVarString(g_cvHitsoundBody, g_sHitsoundBodyPath, sizeof(g_sHitsoundBodyPath));
-	GetConVarString(g_cvHitsoundHead, g_sHitsoundHeadPath, sizeof(g_sHitsoundHeadPath));
-	GetConVarString(g_cvHitsoundKill, g_sHitsoundKillPath, sizeof(g_sHitsoundKillPath));
+	g_cvHitsound.GetString(g_sHitsoundPath, sizeof(g_sHitsoundPath));
+	g_cvHitsoundBody.GetString(g_sHitsoundBodyPath, sizeof(g_sHitsoundBodyPath));
+	g_cvHitsoundHead.GetString(g_sHitsoundHeadPath, sizeof(g_sHitsoundHeadPath));
+	g_cvHitsoundKill.GetString(g_sHitsoundKillPath, sizeof(g_sHitsoundKillPath));
 }
 
 stock void VerifyNatives()

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -1038,7 +1038,7 @@ public void HitmarkerMenu(int client)
 	{
 		menu.SetTitle("Hitmarker Settings\n ");
 
-		switch(g_HM_pData[client].enable)
+		switch (g_HM_pData[client].enable)
 		{
 			case 0:
 				Format(buffer, sizeof(buffer), "Disabled");
@@ -1053,7 +1053,7 @@ public void HitmarkerMenu(int client)
 	else
 	{
 		menu.SetTitle("Hitmarkers\n \nCurrent Style (%d/%d):\n%s", g_HM_pData[client].style + 1, sizeof(g_sHitStyles), g_sHitStyles[g_HM_pData[client].style]);
-		switch(g_HM_pData[client].enable)
+		switch (g_HM_pData[client].enable)
 		{
 			case 0:
 				Format(buffer, sizeof(buffer), "Disabled");
@@ -1074,7 +1074,7 @@ public void HitmarkerMenu(int client)
 		menu.AddItem("bodycolor", buffer);
 	}
 
-	switch(g_HM_pData[client].type)
+	switch (g_HM_pData[client].type)
 	{
 		case 0:
 			Format(buffer, sizeof(buffer), "Game Center");
@@ -1086,7 +1086,7 @@ public void HitmarkerMenu(int client)
 	Format(buffer, sizeof(buffer), "Display Type: %s", buffer);
 	menu.AddItem("display", buffer);
 
-	switch(g_HM_pData[client].damage)
+	switch (g_HM_pData[client].damage)
 	{
 		case 0:
 			Format(buffer, sizeof(buffer), "Off");
@@ -1098,7 +1098,7 @@ public void HitmarkerMenu(int client)
 	Format(buffer, sizeof(buffer), "Show Damage: %s", buffer);
 	menu.AddItem("showdamage", buffer);
 
-	switch(g_HM_pData[client].health)
+	switch (g_HM_pData[client].health)
 	{
 		case 0:
 			Format(buffer, sizeof(buffer), "Off");

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -195,7 +195,6 @@ public void OnPluginStart()
 	// Client cookies
 	SetCookieMenuItem(SettingsMenuHandler, INVALID_HANDLE, "Hitmarker Settings");
 	SetCookieMenuItem(CookieMenu_HitMarker, INVALID_HANDLE, "Hit Sound Settings");
-	
 
 	g_cShowDamage = new Cookie("hitmarker_damage", "Show damage under hitmarker", CookieAccess_Private);
 	g_cShowHitmarker = new Cookie("hitmarker_enable", "Show hitmarkers", CookieAccess_Private);
@@ -595,7 +594,7 @@ public Action Command_HeadColor(int client, int args)
 	Format(buffer, sizeof(buffer), "%d %d %d", r, g, b);
 	g_cHeadshotColor.Set(client, buffer);
 
-	CReplyToCommand(client, "{green}[HitMarker]{default} You have set your headshot hitmarker color to {red}%d {green}%d {blue}%d", r, g, b);
+	CReplyToCommand(client, "%t %t", "Hitmarker Prefix", "Head Color", r, g, b);
 	return Plugin_Handled;
 }
 
@@ -633,7 +632,7 @@ public Action Command_BodyColor(int client, int args)
 	Format(buffer, sizeof(buffer), "%d %d %d", r, g, b);
 	g_cBodyshotColor.Set(client, buffer);
 
-	CReplyToCommand(client, "{green}[HitMarker]{default} You have set your headshot hitmarker color to {red}%d {green}%d {blue}%d", r, g, b);
+	CReplyToCommand(client, "%t %t", "Hitmarker Prefix", "Body Color", r, g, b);
 	return Plugin_Handled;
 }
 
@@ -648,20 +647,20 @@ public Action Command_Hitsound(int client, int args)
 		{
 			g_HS_pData[client].enable = false;
 			g_cEnable.Set(client, "0");
-			CPrintToChat(client, "{green}[HitSound]{default} Hitsounds have been {red}disabled!");
+			CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Disabled");
 		}
 		else
-			CPrintToChat(client, "{green}[HitSound]{default} Hitsounds are already {red}disabled!");
+			CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Already Disabled");
 	}
 	else if (strcmp(buffer, "on", false) == 0)
 	{
 		if (g_HS_pData[client].enable)
-			CPrintToChat(client, "{green}[HitSound]{default} Hitsounds are already {green}enabled!");
+			CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Already Enabled");
 		else
 		{
 			g_HS_pData[client].enable = true;
 			g_cEnable.Set(client, "1");
-			CPrintToChat(client, "{green}[HitSound]{default} Hitsounds have been {green}enabled!");
+			CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Enabled");
 		}
 	}
 	else
@@ -675,7 +674,7 @@ public Action Command_Hitsound(int client, int args)
 
 			g_HS_pData[client].volume = input;
 			g_HS_pData[client].fVolume = fVolume;
-			CPrintToChat(client, "{green}[HitSound]{default} Hitsound volume has been changed to {green}%d", input);
+			CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Volume", input);
 			g_cVolume.Set(client, recalc);
 		}
 		else
@@ -692,18 +691,18 @@ void InternalToggleHitmarker(int client)
 	g_HM_pData[client].enable++;
 	if (g_HM_pData[client].enable > 2)
 		g_HM_pData[client].enable = 0;
-	
+
 	char buffer[32];
 	Format(buffer, sizeof(buffer), "%d", g_HM_pData[client].enable);
 	g_cShowHitmarker.Set(client, buffer);
 	switch (g_HM_pData[client].enable)
 	{
 		case 0:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarkers are now {red}disabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Disabled");
 		case 1:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarkers are now {green}enabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker Enabled");
 		case 2:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarkers are now {green}enabled (Players + Bosses)");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Hitmarker All");
 	}
 }
 
@@ -712,18 +711,18 @@ void InternalToggleDamage(int client)
 	g_HM_pData[client].damage++;
 	if (g_HM_pData[client].damage > 2)
 		g_HM_pData[client].damage = 0;
-	
+
 	char buffer[32];
 	Format(buffer, sizeof(buffer), "%d", g_HM_pData[client].damage);
 	g_cShowDamage.Set(client, buffer);
 	switch (g_HM_pData[client].damage)
 	{
 		case 0:
-			CPrintToChat(client, "{green}[HitMarker]{default} Damage display under hitmarkers is now {red}disabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Disabled");
 		case 1:
-			CPrintToChat(client, "{green}[HitMarker]{default} Damage display under hitmarkers is now {green}enabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Enabled");
 		case 2:
-			CPrintToChat(client, "{green}[HitMarker]{default} Damage display under hitmarkers is now {green}enabled (+Rank)");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Damage Rank");
 	}
 }
 
@@ -732,18 +731,18 @@ void InternalToggleDisplayType(int client)
 	g_HM_pData[client].type++;
 	if (g_HM_pData[client].type > 2)
 		g_HM_pData[client].type = 0;
-	
+
 	char buffer[32];
 	Format(buffer, sizeof(buffer), "%d", g_HM_pData[client].type);
 	g_cDisplayType.Set(client, buffer);
 	switch (g_HM_pData[client].type)
 	{
 		case 0:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarker display type is now using {green}Game Center");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Center");
 		case 1:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarker display type is now using {green}Game_text");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Game Text");
 		case 2:
-			CPrintToChat(client, "{green}[HitMarker]{default} Hitmarker display type is now using {green}Hint");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Type Hint Text");
 	}
 }
 
@@ -752,18 +751,18 @@ void InternalToggleShowHealth(int client)
 	g_HM_pData[client].health++;
 	if (g_HM_pData[client].health > 2)
 		g_HM_pData[client].health = 0;
-	
+
 	char buffer[32];
 	Format(buffer, sizeof(buffer), "%d", g_HM_pData[client].health);
 	g_cShowHealth.Set(client, buffer);
 	switch (g_HM_pData[client].health)
 	{
 		case 0:
-			CPrintToChat(client, "{green}[HitMarker]{default} Health display under hitmarkers is now {red}disabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Disabled");
 		case 1:
-			CPrintToChat(client, "{green}[HitMarker]{default} Health display under hitmarkers is now {green}enabled");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Enabled");
 		case 2:
-			CPrintToChat(client, "{green}[HitMarker]{default} Health display under hitmarkers is now {green}enabled (+Victim name)");
+			CPrintToChat(client, "%t %t", "Hitmarker Prefix", "Health Name");
 	}
 }
 
@@ -859,7 +858,7 @@ public void Event_PlayerHurt(Handle event, const char[] name, bool broadcast)
 		// The Hitmarker is not enabled but we still need to Format for damage or/and health
 		if (!g_HM_pData[attacker].enable)
 			Format(buffer, sizeof(buffer), "\n\n\n\n\n\n\n\n");
-	
+
 		// For this display we need to always set the new line at the end of the string
 		// This is because we re-use the buffer for each line
 		if (g_bShowDamage && g_HM_pData[attacker].damage != 0)
@@ -928,7 +927,7 @@ public void Hook_EntityOnDamage(const char[] output, int caller, int activator, 
 }
 
 void SendHudMsg(int client, char[] szMessage, DisplayType type = DISPLAY_HINT, int hitgroup = 0)
-{	
+{
 	if (type == DISPLAY_HINT && IsVoteInProgress())
 		type = DISPLAY_GAME;
 
@@ -1005,8 +1004,8 @@ public void OnMapEnd()
 	Cleanup();
 }
 
-public void Event_OnRoundEnd(Event event, const char[] name, bool dontBroadcast) 
-{ 
+public void Event_OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
+{
 	CleanupAndInit();
 }
 
@@ -1038,7 +1037,7 @@ public void HitmarkerMenu(int client)
 	if (g_HM_pData[client].enable == 0)
 	{
 		menu.SetTitle("Hitmarker Settings\n ");
-		
+
 		switch(g_HM_pData[client].enable)
 		{
 			case 0:
@@ -1416,7 +1415,7 @@ public int MenuHandler_HitMarker(Menu menu, MenuAction action, int client, int s
 					Format(buffer, sizeof(buffer), "%.2f", g_HS_pData[client].fVolume);
 					g_cVolume.Set(client, buffer);
 
-					CPrintToChat(client, "{green}[HitSound]{default} Hitsound volume has been changed to {green}%d", g_HS_pData[client].volume);
+					CPrintToChat(client, "%t %t", "Hitsound Prefix", "Hitsound Volume", g_HS_pData[client].volume);
 				}
 			}
 			DisplayCookieMenu(client);
@@ -1428,21 +1427,21 @@ public int MenuHandler_HitMarker(Menu menu, MenuAction action, int client, int s
 public void ToggleZombieHitsound(int client)
 {
 	g_HS_pData[client].enable = !g_HS_pData[client].enable;
-	CPrintToChat(client, "{green}[HitSound]{default} Zombie hitsounds are now %s", g_HS_pData[client].enable ? "{green}enabled" : "{red}disabled");
+	CPrintToChat(client, "%t %t", "Hitsound Prefix", "Toggle Zombie", g_HS_pData[client].enable ? "Enabled" : "Disabled");
 	g_HS_pData[client].enable ? g_cEnable.Set(client, "1") : g_cEnable.Set(client, "0");
 }
 
 public void ToggleBossHitsound(int client)
 {
 	g_HS_pData[client].boss = !g_HS_pData[client].boss;
-	CPrintToChat(client, "{green}[HitSound]{default} Boss hitsounds are now %s", g_HS_pData[client].boss ? "{green}enabled" : "{red}disabled");
+	CPrintToChat(client, "%t %t", "Hitsound Prefix", "Toggle Boss", g_HS_pData[client].boss ? "Enabled" : "Disabled");
 	g_HS_pData[client].boss ? g_cBoss.Set(client, "1") : g_cBoss.Set(client, "0");
 }
 
 public void ToggleDetailedHitsound(int client)
 {
 	g_HS_pData[client].detailed = !g_HS_pData[client].detailed;
-	CPrintToChat(client, "{green}[HitSound]{default} Detailed hitsounds are now %s", g_HS_pData[client].detailed ? "{green}enabled" : "{red}disabled");
+	CPrintToChat(client, "%t %t", "Hitsound Prefix", "Toggle Detailed", g_HS_pData[client].detailed ? "Enabled" : "Disabled");
 	g_HS_pData[client].detailed ? g_cDetailed.Set(client, "1") : g_cDetailed.Set(client, "0");
 }
 

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -775,7 +775,7 @@ public void Event_PlayerHurt(Handle event, const char[] name, bool broadcast)
 	if (!(1 <= attacker <= MaxClients) || !IsClientInGame(attacker))
 		return;
 
-	if (!IsPlayerAlive(attacker))
+	if (!IsPlayerAlive(attacker) || GetClientTeam(attacker) == CS_TEAM_T)
 		return;
 
 	// Only perform 1 hitmarker/hitsound per tick

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -164,10 +164,8 @@ public void OnPluginStart()
 	AutoExecConfig(true, "Hitmarkers");
 
 	// Plugin commands
-	RegConsoleCmd("sm_hm", Command_Hitmarkers, "Open hitmarkers settings");
 	RegConsoleCmd("sm_hitmarker", Command_Hitmarkers, "Open hitmarker settings");
 	RegConsoleCmd("sm_hitmarkers", Command_Hitmarkers, "Open hitmarker settings");
-	RegConsoleCmd("sm_sd", Command_Hitmarkers, "Open hitmarkers settings");
 	RegConsoleCmd("sm_showdamage", Command_Hitmarkers, "Open hitmarkers settings");
 
 	RegConsoleCmd("sm_headhitcolor", Command_HeadColor, "Change your zombie hitmarker color.");
@@ -176,7 +174,6 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_bodyhitcolor", Command_BodyColor, "Change your zombie hitmarker color.");
 	RegConsoleCmd("sm_bodyhitcolour", Command_BodyColor, "Change your zombie hitmarker color.");
 
-	RegConsoleCmd("sm_hits", Command_Hitsound, "Bring up hitsounds settings menu");
 	RegConsoleCmd("sm_hitsound", Command_Hitsound, "Bring up hitsounds settings menu");
 	RegConsoleCmd("sm_hitsounds", Command_Hitsound, "Bring up hitsounds settings menu");
 

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -617,9 +617,9 @@ public Action Command_HeadColor(int client, int args)
 	GetCmdArg(3, buffer, sizeof(buffer));
 	b = StringToInt(buffer);
 
-	if (r > 255) r = 255; if (r < 0) r = 0;
-	if (g > 255) g = 255; if (g < 0) g = 0;
-	if (b > 255) b = 255; if (b < 0) b = 0;
+	if (r > 255) r = 255; else if (r < 0) r = 0;
+	if (g > 255) g = 255; else if (g < 0) g = 0;
+	if (b > 255) b = 255; else if (b < 0) b = 0;
 
 	g_HM_pData[client].headColor[0] = r;
 	g_HM_pData[client].headColor[1] = g;
@@ -649,9 +649,9 @@ public Action Command_BodyColor(int client, int args)
 	GetCmdArg(3, buffer, sizeof(buffer));
 	b = StringToInt(buffer);
 
-	if (r > 255) r = 255; if (r < 0) r = 0;
-	if (g > 255) g = 255; if (g < 0) g = 0;
-	if (b > 255) b = 255; if (b < 0) b = 0;
+	if (r > 255) r = 255; else if (r < 0) r = 0;
+	if (g > 255) g = 255; else if (g < 0) g = 0;
+	if (b > 255) b = 255; else if (b < 0) b = 0;
 
 	g_HM_pData[client].bodyColor[0] = r;
 	g_HM_pData[client].bodyColor[1] = g;

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -141,7 +141,7 @@ public Plugin myinfo =
 
 public void OnPluginStart()
 {
-	// LoadTranslations("plugin.hitmarkers.phrases");
+	LoadTranslations("HitMarker.phrases");
 
 	// HitMarker convars
 	g_cvEnable = CreateConVar("sm_hitmarker_enable", "1", "Enable hitmarkers");

--- a/addons/sourcemod/scripting/HitMarker.sp
+++ b/addons/sourcemod/scripting/HitMarker.sp
@@ -185,7 +185,7 @@ public void OnPluginStart()
 	// Client cookies
 	SetCookieMenuItem(SettingsMenuHandler, INVALID_HANDLE, "Hitmarker Settings");
 	SetCookieMenuItem(CookieMenu_HitMarker, INVALID_HANDLE, "Hit Sound Settings");
-	
+
 
 	g_cHitmarkerSettings = new Cookie("hitmarker_settings", "Combined hitmarker settings (damage|enable|health|type|style)", CookieAccess_Private);
 	g_cHitmarkerColors = new Cookie("hitmarker_colors", "Combined hitmarker colors (headR|headG|headB|bodyR|bodyG|bodyB)", CookieAccess_Private);
@@ -408,7 +408,7 @@ public int Native_SetHitsoundVolume(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
 	int volume = GetNativeCell(2);
-	
+
 	g_HS_pData[client].volume = volume;
 	g_HS_pData[client].fVolume = volume / 100.0;
 	SaveHitsoundSettings(client);
@@ -427,11 +427,11 @@ public int Native_OpenHitsoundMenu(Handle plugin, int numParams)
 void SaveHitmarkerSettings(int client)
 {
 	char buffer[32];
-	Format(buffer, sizeof(buffer), "%d|%d|%d|%d|%d", 
-		g_HM_pData[client].damage, 
-		g_HM_pData[client].enable, 
-		g_HM_pData[client].health, 
-		g_HM_pData[client].type, 
+	Format(buffer, sizeof(buffer), "%d|%d|%d|%d|%d",
+		g_HM_pData[client].damage,
+		g_HM_pData[client].enable,
+		g_HM_pData[client].health,
+		g_HM_pData[client].type,
 		g_HM_pData[client].style);
 	g_cHitmarkerSettings.Set(client, buffer);
 }
@@ -490,7 +490,7 @@ void LoadHitmarkerSettings(int client)
 void SaveHitmarkerColors(int client)
 {
 	char buffer[32];
-	Format(buffer, sizeof(buffer), "%d|%d|%d|%d|%d|%d", 
+	Format(buffer, sizeof(buffer), "%d|%d|%d|%d|%d|%d",
 		g_HM_pData[client].headColor[0], g_HM_pData[client].headColor[1], g_HM_pData[client].headColor[2],
 		g_HM_pData[client].bodyColor[0], g_HM_pData[client].bodyColor[1], g_HM_pData[client].bodyColor[2]);
 	g_cHitmarkerColors.Set(client, buffer);
@@ -551,7 +551,7 @@ void LoadHitmarkerColors(int client)
 void SaveHitsoundSettings(int client)
 {
 	char buffer[32];
-	Format(buffer, sizeof(buffer), "%d|%d|%d|%d", 
+	Format(buffer, sizeof(buffer), "%d|%d|%d|%d",
 		g_HS_pData[client].enable ? 1 : 0,
 		g_HS_pData[client].boss ? 1 : 0,
 		g_HS_pData[client].detailed ? 1 : 0,
@@ -758,7 +758,7 @@ void InternalToggleHitmarker(int client)
 	g_HM_pData[client].enable++;
 	if (g_HM_pData[client].enable > 2)
 		g_HM_pData[client].enable = 0;
-	
+
 	SaveHitmarkerSettings(client);
 	switch (g_HM_pData[client].enable)
 	{
@@ -1065,7 +1065,7 @@ public void OnMapEnd()
 	Cleanup();
 }
 
-public void Event_OnRoundEnd(Event event, const char[] name, bool dontBroadcast) 
+public void Event_OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
 {
 	CleanupAndInit();
 }

--- a/addons/sourcemod/scripting/include/hitmarkers.inc
+++ b/addons/sourcemod/scripting/include/hitmarkers.inc
@@ -4,7 +4,7 @@
 #define _hitmarkers_included
 
 #define HitMarker_V_MAJOR   "2"
-#define HitMarker_V_MINOR   "1"
+#define HitMarker_V_MINOR   "2"
 #define HitMarker_V_PATCH   "0"
 
 #define HitMarker_VERSION   HitMarker_V_MAJOR..."."...HitMarker_V_MINOR..."."...HitMarker_V_PATCH

--- a/addons/sourcemod/scripting/include/hitmarkers.inc
+++ b/addons/sourcemod/scripting/include/hitmarkers.inc
@@ -4,8 +4,8 @@
 #define _hitmarkers_included
 
 #define HitMarker_V_MAJOR   "2"
-#define HitMarker_V_MINOR   "0"
-#define HitMarker_V_PATCH   "1"
+#define HitMarker_V_MINOR   "1"
+#define HitMarker_V_PATCH   "0"
 
 #define HitMarker_VERSION   HitMarker_V_MAJOR..."."...HitMarker_V_MINOR..."."...HitMarker_V_PATCH
 

--- a/addons/sourcemod/translations/HitMarker.phrases.txt
+++ b/addons/sourcemod/translations/HitMarker.phrases.txt
@@ -6,6 +6,7 @@
         "en"        "{green}[HitMarker]{white}"
         "zho"       "{green}[HitMarker]{white}"
         "chi"       "{green}[HitMarker]{white}"
+        "fr"        "{green}[HitMarker]{white}"
     }
 
     "Hitsound Prefix"
@@ -13,6 +14,7 @@
         "en"        "{green}[HitSound]{white}"
         "zho"       "{green}[HitSound]{white}"
         "chi"       "{green}[HitSound]{white}"
+        "fr"        "{green}[HitSound]{white}"
     }
 
     // Hitmarker
@@ -21,6 +23,7 @@
         "en"        "You have {red}disabled {white}hitmarkers."
         "zho"       "已{red}停用{white}命中標記。"
         "chi"       "已{red}停用{white}命中标记。"
+        "fr"        "Vous avez {red}désactivé {white}les marqueurs de coup."
     }
 
     "Hitmarker Enabled"
@@ -28,6 +31,7 @@
         "en"        "You have {green}enabled {white}hitmarkers."
         "zho"       "已{green}開啓{white}命中標記。"
         "chi"       "已{green}开启{white}命中标记。"
+        "fr"        "Vous avez {green}activé {white}les marqueurs de coup."
     }
 
     "Hitmarker All"
@@ -35,6 +39,7 @@
         "en"        "You have {green}enabled {white}hitmarkers {blue}(Players + Bosses){white}."
         "zho"       "已{green}開啓{white}命中標記{blue}（玩家 + Boss）。"
         "chi"       "已{green}开启{white}命中标记{blue}（玩家 + Boss）。"
+        "fr"        "Vous avez {green}activé {white}les marqueurs de coup {blue}(Joueurs + Boss){white}."
     }
 
     "Damage Disabled"
@@ -42,6 +47,7 @@
         "en"        "Damage display is now {red}disabled{white}."
         "zho"       "已{red}停用{white}命中傷害顯示。"
         "chi"       "已{red}停用{white}命中伤害显示。"
+        "fr"        "L'affichage des dégâts est maintenant {red}désactivé{white}."
     }
 
     "Damage Enabled"
@@ -49,6 +55,7 @@
         "en"        "Damage display is now {green}enabled{white}."
         "zho"       "已{green}開啓{white}命中傷害顯示。"
         "chi"       "已{green}开启{white}命中伤害显示。"
+        "fr"        "L'affichage des dégâts est maintenant {green}activé{white}."
     }
 
     "Damage Rank"
@@ -56,6 +63,7 @@
         "en"        "Damage display with ranking is now {green}enabled{white}."
         "zho"       "已{green}開啓{white}命中傷害跟排名顯示。"
         "chi"       "已{green}开启{white}命中伤害跟排名显示。"
+        "fr"        "L'affichage des dégâts avec classement est maintenant {green}activé{white}."
     }
 
     "Type Center"
@@ -63,6 +71,7 @@
         "en"        "Damage dealt is now being displayed as \"{blue}center text{white}\"."
         "zho"       "傷害顯示方式已改成\"{blue}center text{white}\"。"
         "chi"       "伤害显示方式已改成\"{blue}center text{white}\"。"
+        "fr"        "Les dégâts infligés sont maintenant affichés comme \"{blue}texte central{white}\"."
     }
 
     "Type Game Text"
@@ -70,6 +79,7 @@
         "en"        "Damage dealt is now being displayed as \"{blue}game text{white}\"."
         "zho"       "傷害顯示方式已改成\"{blue}game text{white}\"。"
         "chi"       "伤害显示方式已改成\"{blue}game text{white}\"。"
+        "fr"        "Les dégâts infligés sont maintenant affichés comme \"{blue}texte du jeu{white}\"."
     }
 
     "Type Hint Text"
@@ -77,6 +87,7 @@
         "en"        "Damage dealt is now being displayed as \"{blue}hint text{white}\"."
         "zho"       "傷害顯示方式已改成\"{blue}hint text{white}\"。"
         "chi"       "伤害显示方式已改成\"{blue}hint text{white}\"。"
+        "fr"        "Les dégâts infligés sont maintenant affichés comme \"{blue}texte d'indice{white}\"."
     }
 
     "Health Disabled"
@@ -84,13 +95,15 @@
         "en"        "Remaining health display is now {red}disabled{white}."
         "zho"       "已{red}停用{white}對方剩下血量顯示。"
         "chi"       "已{red}停用{white}对方剩下血量显示。"
+        "fr"        "L'affichage de la santé restante est maintenant {red}désactivé{white}."
     }
 
     "Health Enabled"
     {
         "en"        "Remaining health display is now {green}enabled{white}."
         "zho"       "已{green}開啓{white}對方剩下血量顯示。"
-        "chi"       "已{green}开启{white}对方剩下血量显示。"
+        "chi"       "已{green}开启{white}對方剩下血量顯示。"
+        "fr"        "L'affichage de la santé restante est maintenant {green}activé{white}."
     }
 
     "Health Name"
@@ -98,6 +111,7 @@
         "en"        "Remaining health display is now {green}enabled{white} with {blue}victim name{white}."
         "zho"       "已{green}開啓{white}對方名字跟剩下血量顯示。"
         "chi"       "已{green}开启{white}对方名字跟剩下血量显示。"
+        "fr"        "L'affichage de la santé restante est maintenant {green}activé{white} avec le {blue}nom de la victime{white}."
     }
 
     "Head Color"
@@ -106,6 +120,7 @@
         "en"        "You have set your headshot hitmarker color to {red}{1} {green}{2} {blue}{3}{white}."
         "zho"       "頭的命中標記顔色已調到 {red}{1} {green}{2} {blue}{3}{white}。"
         "chi"       "头的命中标记颜色已调到 {red}{1} {green}{2} {blue}{3}{white}。"
+        "fr"        "Vous avez défini la couleur de votre marqueur de coup à la tête sur {red}{1} {green}{2} {blue}{3}{white}."
     }
 
     "Body Color"
@@ -114,6 +129,7 @@
         "en"        "You have set your bodyshot hitmarker color to {red}{1} {green}{2} {blue}{3}{white}."
         "zho"       "身體的命中標記顔色已調到 {red}{1} {green}{2} {blue}{3}{white}。"
         "chi"       "身体的命中标记颜色已调到 {red}{1} {green}{2} {blue}{3}{white}。"
+        "fr"        "Vous avez défini la couleur de votre marqueur de coup au corps sur {red}{1} {green}{2} {blue}{3}{white}."
     }
 
     // Hitsound
@@ -122,6 +138,7 @@
         "en"        "Hitsounds have been {red}disabled{white}!"
         "zho"       "子弹命中音效已{red}屏蔽{white}!"
         "chi"       "子弹命中音效已{red}屏蔽{white}!"
+        "fr"        "Les sons de coup ont été {red}désactivés{white}!"
     }
 
     "Hitsound Enabled"
@@ -129,6 +146,7 @@
         "en"        "Hitsounds have been {green}enabled{white}!"
         "zho"       "已{green}開啓{white}子彈命中音效!"
         "chi"       "已{green}开启{white}子弹命中音效!"
+        "fr"        "Les sons de coup ont été {green}activés{white}!"
     }
 
     "Hitsound Already Disabled"
@@ -136,6 +154,7 @@
         "en"        "Hitsounds are already {red}disabled{white}!"
         "zho"       "子彈命中音效已經{red}屏蔽{white}了!"
         "chi"       "子弹命中音效已经{red}屏蔽{white}了!"
+        "fr"        "Les sons de coup sont déjà {red}désactivés{white}!"
     }
 
     "Hitsound Already Enabled"
@@ -143,6 +162,7 @@
         "en"        "Hitsounds are already {green}enabled{white}!"
         "zho"       "子彈命中音效已經{green}開啓{white}了!"
         "chi"       "子弹命中音效已经{green}开启{white}了!"
+        "fr"        "Les sons de coup sont déjà {green}activés{white}!"
     }
 
     "Hitsound Volume"
@@ -151,6 +171,7 @@
         "en"        "Hitsound volume has been changed to {green}{1}{white}."
         "zho"       "子彈命中音效音量已調到{green}{1}{white}。"
         "chi"       "子弹命中音效音量已调到{green}{1}{white}。"
+        "fr"        "Le volume des sons de coup a été changé à {green}{1}{white}."
     }
 
     // Internal
@@ -159,6 +180,7 @@
         "en"        "{green}enabled"
         "zho"       "{green}開啓"
         "chi"       "{green}开启"
+        "fr"        "{green}activé"
     }
 
     "Disabled"
@@ -166,6 +188,7 @@
         "en"        "{red}disabled"
         "zho"       "{red}停用"
         "chi"       "{red}停用"
+        "fr"        "{red}désactivé"
     }
 
     "Toggle Zombie"
@@ -174,6 +197,7 @@
         "en"        "Zombie hitsounds are now {1}{white}."
         "zho"       "已{1}{white}僵尸命中音效。"
         "chi"       "已{1}{white}僵尸命中音效。"
+        "fr"        "Les sons de coup de zombie sont maintenant {1}{white}."
     }
 
     "Toggle Boss"
@@ -182,6 +206,7 @@
         "en"        "Boss hitsounds are now {1}{white}."
         "zho"       "已{1}{white}boss命中音效。"
         "chi"       "已{1}{white}boss命中音效。"
+        "fr"        "Les sons de coup de boss sont maintenant {1}{white}."
     }
 
     "Toggle Detailed"
@@ -190,5 +215,6 @@
         "en"        "Detailed hitsounds are now {1}{white}."
         "zho"       "已{1}{white}頭部跟身體命中音效。"
         "chi"       "已{1}{white}头部跟身体命中音效。"
+        "fr"        "Les sons de coup détaillés sont maintenant {1}{white}."
     }
 }

--- a/addons/sourcemod/translations/HitMarker.phrases.txt
+++ b/addons/sourcemod/translations/HitMarker.phrases.txt
@@ -1,0 +1,194 @@
+"Phrases"
+{
+    // Prefix
+    "Hitmarker Prefix"
+    {
+        "en"        "{green}[HitMarker]{white}"
+        "zho"       "{green}[HitMarker]{white}"
+        "chi"       "{green}[HitMarker]{white}"
+    }
+
+    "Hitsound Prefix"
+    {
+        "en"        "{green}[HitSound]{white}"
+        "zho"       "{green}[HitSound]{white}"
+        "chi"       "{green}[HitSound]{white}"
+    }
+
+    // Hitmarker
+    "Hitmarker Disabled"
+    {
+        "en"        "You have {red}disabled {white}hitmarkers."
+        "zho"       "已{red}停用{white}命中標記。"
+        "chi"       "已{red}停用{white}命中标记。"
+    }
+
+    "Hitmarker Enabled"
+    {
+        "en"        "You have {green}enabled {white}hitmarkers."
+        "zho"       "已{green}開啓{white}命中標記。"
+        "chi"       "已{green}开启{white}命中标记。"
+    }
+
+    "Hitmarker All"
+    {
+        "en"        "You have {green}enabled {white}hitmarkers {blue}(Players + Bosses){white}."
+        "zho"       "已{green}開啓{white}命中標記{blue}（玩家 + Boss）。"
+        "chi"       "已{green}开启{white}命中标记{blue}（玩家 + Boss）。"
+    }
+
+    "Damage Disabled"
+    {
+        "en"        "Damage display is now {red}disabled{white}."
+        "zho"       "已{red}停用{white}命中傷害顯示。"
+        "chi"       "已{red}停用{white}命中伤害显示。"
+    }
+
+    "Damage Enabled"
+    {
+        "en"        "Damage display is now {green}enabled{white}."
+        "zho"       "已{green}開啓{white}命中傷害顯示。"
+        "chi"       "已{green}开启{white}命中伤害显示。"
+    }
+
+    "Damage Rank"
+    {
+        "en"        "Damage display with ranking is now {green}enabled{white}."
+        "zho"       "已{green}開啓{white}命中傷害跟排名顯示。"
+        "chi"       "已{green}开启{white}命中伤害跟排名显示。"
+    }
+
+    "Type Center"
+    {
+        "en"        "Damage dealt is now being displayed as \"{blue}center text{white}\"."
+        "zho"       "傷害顯示方式已改成\"{blue}center text{white}\"。"
+        "chi"       "伤害显示方式已改成\"{blue}center text{white}\"。"
+    }
+
+    "Type Game Text"
+    {
+        "en"        "Damage dealt is now being displayed as \"{blue}game text{white}\"."
+        "zho"       "傷害顯示方式已改成\"{blue}game text{white}\"。"
+        "chi"       "伤害显示方式已改成\"{blue}game text{white}\"。"
+    }
+
+    "Type Hint Text"
+    {
+        "en"        "Damage dealt is now being displayed as \"{blue}hint text{white}\"."
+        "zho"       "傷害顯示方式已改成\"{blue}hint text{white}\"。"
+        "chi"       "伤害显示方式已改成\"{blue}hint text{white}\"。"
+    }
+
+    "Health Disabled"
+    {
+        "en"        "Remaining health display is now {red}disabled{white}."
+        "zho"       "已{red}停用{white}對方剩下血量顯示。"
+        "chi"       "已{red}停用{white}对方剩下血量显示。"
+    }
+
+    "Health Enabled"
+    {
+        "en"        "Remaining health display is now {green}enabled{white}."
+        "zho"       "已{green}開啓{white}對方剩下血量顯示。"
+        "chi"       "已{green}开启{white}对方剩下血量显示。"
+    }
+
+    "Health Name"
+    {
+        "en"        "Remaining health display is now {green}enabled{white} with {blue}victim name{white}."
+        "zho"       "已{green}開啓{white}對方名字跟剩下血量顯示。"
+        "chi"       "已{green}开启{white}对方名字跟剩下血量显示。"
+    }
+
+    "Head Color"
+    {
+        "#format"   "{1:i},{2:i},{3:i}"
+        "en"        "You have set your headshot hitmarker color to {red}{1} {green}{2} {blue}{3}{white}."
+        "zho"       "頭的命中標記顔色已調到 {red}{1} {green}{2} {blue}{3}{white}。"
+        "chi"       "头的命中标记颜色已调到 {red}{1} {green}{2} {blue}{3}{white}。"
+    }
+
+    "Body Color"
+    {
+        "#format"   "{1:i},{2:i},{3:i}"
+        "en"        "You have set your bodyshot hitmarker color to {red}{1} {green}{2} {blue}{3}{white}."
+        "zho"       "身體的命中標記顔色已調到 {red}{1} {green}{2} {blue}{3}{white}。"
+        "chi"       "身体的命中标记颜色已调到 {red}{1} {green}{2} {blue}{3}{white}。"
+    }
+
+    // Hitsound
+    "Hitsound Disabled"
+    {
+        "en"        "Hitsounds have been {red}disabled{white}!"
+        "zho"       "子弹命中音效已{red}屏蔽{white}!"
+        "chi"       "子弹命中音效已{red}屏蔽{white}!"
+    }
+
+    "Hitsound Enabled"
+    {
+        "en"        "Hitsounds have been {green}enabled{white}!"
+        "zho"       "已{green}開啓{white}子彈命中音效!"
+        "chi"       "已{green}开启{white}子弹命中音效!"
+    }
+
+    "Hitsound Already Disabled"
+    {
+        "en"        "Hitsounds are already {red}disabled{white}!"
+        "zho"       "子彈命中音效已經{red}屏蔽{white}了!"
+        "chi"       "子弹命中音效已经{red}屏蔽{white}了!"
+    }
+
+    "Hitsound Already Enabled"
+    {
+        "en"        "Hitsounds are already {green}enabled{white}!"
+        "zho"       "子彈命中音效已經{green}開啓{white}了!"
+        "chi"       "子弹命中音效已经{green}开启{white}了!"
+    }
+
+    "Hitsound Volume"
+    {
+        "#format"   "{1:i}"
+        "en"        "Hitsound volume has been changed to {green}{1}{white}."
+        "zho"       "子彈命中音效音量已調到{green}{1}{white}。"
+        "chi"       "子弹命中音效音量已调到{green}{1}{white}。"
+    }
+
+    // Internal
+    "Enabled"
+    {
+        "en"        "{green}enabled"
+        "zho"       "{green}開啓"
+        "chi"       "{green}开启"
+    }
+
+    "Disabled"
+    {
+        "en"        "{red}disabled"
+        "zho"       "{red}停用"
+        "chi"       "{red}停用"
+    }
+
+    "Toggle Zombie"
+    {
+        "#format"   "{1:t}"
+        "en"        "Zombie hitsounds are now {1}{white}."
+        "zho"       "已{1}{white}僵尸命中音效。"
+        "chi"       "已{1}{white}僵尸命中音效。"
+    }
+
+    "Toggle Boss"
+    {
+        "#format"   "{1:t}"
+        "en"        "Boss hitsounds are now {1}{white}."
+        "zho"       "已{1}{white}boss命中音效。"
+        "chi"       "已{1}{white}boss命中音效。"
+    }
+
+    "Toggle Detailed"
+    {
+        "#format"   "{1:t}"
+        "en"        "Detailed hitsounds are now {1}{white}."
+        "zho"       "已{1}{white}頭部跟身體命中音效。"
+        "chi"       "已{1}{white}头部跟身体命中音效。"
+    }
+}

--- a/addons/sourcemod/translations/HitMarker.phrases.txt
+++ b/addons/sourcemod/translations/HitMarker.phrases.txt
@@ -102,7 +102,7 @@
     {
         "en"        "Remaining health display is now {green}enabled{white}."
         "zho"       "已{green}開啓{white}對方剩下血量顯示。"
-        "chi"       "已{green}开启{white}對方剩下血量顯示。"
+        "chi"       "已{green}开启{white}对方剩下血量显示。"
         "fr"        "L'affichage de la santé restante est maintenant {green}activé{white}."
     }
 


### PR DESCRIPTION
Changes made in this pull request:
\- Added translations file support (`en`/`zho`/`chi`/`fr`)
\- Reworked `sm_hitmarker_enable` convar logic so hitsounds still play when hitmarkers are disabled
\- Minor code formatting and linting
\- Fixed several grammar mistakes and added better chat colors
\- Fixed zombies seeing hitmarker when infecting humans
\- Removed extra unneeded commands